### PR TITLE
Gtk3 Update and Style Normalization

### DIFF
--- a/painting_with_cairo/basic_shapes.rb
+++ b/painting_with_cairo/basic_shapes.rb
@@ -6,14 +6,14 @@ class RubyApp < Gtk::Window
     def initialize
         super
     
-        set_title "Basic shapes"
-        signal_connect "destroy" do 
+        set_title('Basic shapes')
+        signal_connect('destroy') do 
             Gtk.main_quit 
         end
         
         init_ui
 
-        set_default_size 390, 240
+        set_default_size(390, 240)
         set_window_position(:center)
         
         show_all
@@ -23,7 +23,7 @@ class RubyApp < Gtk::Window
     
         @darea = Gtk::DrawingArea.new  
         
-        @darea.signal_connect "draw" do  
+        @darea.signal_connect('draw') do  
             on_expose
         end
     
@@ -38,21 +38,21 @@ class RubyApp < Gtk::Window
     
     def draw_shapes cr
     
-        cr.set_source_rgb 0.6, 0.6, 0.6
+        cr.set_source_rgb(0.6, 0.6, 0.6)
 
-        cr.rectangle 20, 20, 120, 80
-        cr.rectangle 180, 20, 80, 80
+        cr.rectangle(20, 20, 120, 80)
+        cr.rectangle(180, 20, 80, 80)
         cr.fill
 
-        cr.arc 330, 60, 40, 0, 2*Math::PI
+        cr.arc(330, 60, 40, 0, 2*Math::PI)
         cr.fill
         
-        cr.arc 90, 160, 40, Math::PI/4, Math::PI
+        cr.arc(90, 160, 40, Math::PI/4, Math::PI)
         cr.fill
 
-        cr.translate 220, 180
-        cr.scale 1, 0.7
-        cr.arc 0, 0, 50, 0, 2*Math::PI
+        cr.translate(220, 180)
+        cr.scale(1, 0.7)
+        cr.arc(0, 0, 50, 0, 2*Math::PI)
         cr.fill
     end
 end

--- a/painting_with_cairo/colors.rb
+++ b/painting_with_cairo/colors.rb
@@ -6,14 +6,14 @@ class RubyApp < Gtk::Window
     def initialize
         super
     
-        set_title "Colors"
-        signal_connect "destroy" do 
+        set_title('Colors')
+        signal_connect('destroy') do 
             Gtk.main_quit 
         end
         
         init_ui
 
-        set_default_size 360, 100
+        set_default_size(360, 100)
         set_window_position(:center)
         show_all
     end
@@ -21,7 +21,7 @@ class RubyApp < Gtk::Window
     def init_ui
     
         @darea = Gtk::DrawingArea.new  
-        # deprecated -> @darea.signal_connect "expose-event" do  
+        # deprecated -> @darea.signal_connect 'expose-event' do  
         #    on_expose
         # end 
         @darea.signal_connect('draw') do  
@@ -41,16 +41,16 @@ class RubyApp < Gtk::Window
     
     def draw_colors cr
         
-        cr.set_source_rgb 0.2, 0.23, 0.9
-        cr.rectangle 10, 15, 90, 60
+        cr.set_source_rgb(0.2, 0.23, 0.9)
+        cr.rectangle(10, 15, 90, 60)
         cr.fill
          
-        cr.set_source_rgb 0.9, 0.1, 0.1
-        cr.rectangle 130, 15, 90, 60
+        cr.set_source_rgb(0.9, 0.1, 0.1)
+        cr.rectangle(130, 15, 90, 60)
         cr.fill
 
-        cr.set_source_rgb 0.4, 0.9, 0.4
-        cr.rectangle 250, 15, 90, 60
+        cr.set_source_rgb(0.4, 0.9, 0.4)
+        cr.rectangle(250, 15, 90, 60)
         cr.fill
     end
 end

--- a/painting_with_cairo/donut.rb
+++ b/painting_with_cairo/donut.rb
@@ -1,4 +1,3 @@
-
 require 'gtk3'
 
 
@@ -7,14 +6,14 @@ class RubyApp < Gtk::Window
     def initialize
         super
     
-        set_title "Donut"
-        signal_connect "destroy" do 
+        set_title('Donut')
+        signal_connect('destroy') do 
             Gtk.main_quit 
         end
         
         init_ui
 
-        set_default_size 350, 250
+        set_default_size(350, 250)
         set_window_position(:center)
         
         show_all
@@ -24,7 +23,7 @@ class RubyApp < Gtk::Window
     
         @darea = Gtk::DrawingArea.new  
         
-        @darea.signal_connect "draw" do  
+        @darea.signal_connect('draw') do  
             on_expose
         end
     
@@ -35,20 +34,20 @@ class RubyApp < Gtk::Window
     def on_expose
     
         cr = @darea.window.create_cairo_context  
-        cr.set_line_width 0.5
+        cr.set_line_width(0.5)
 
         w = allocation.width
         h = allocation.height
        
-        cr.translate w/2, h/2
-        cr.arc 0, 0, 120, 0, 2*Math::PI
+        cr.translate(w/2, h/2)
+        cr.arc(0, 0, 120, 0, 2*Math::PI)
         cr.stroke
          
         for i in (1..36)
             cr.save
-            cr.rotate i*Math::PI/36
-            cr.scale 0.3, 1
-            cr.arc 0, 0, 120, 0, 2*Math::PI
+            cr.rotate(i*Math::PI/36)
+            cr.scale(0.3, 1)
+            cr.arc(0, 0, 120, 0, 2*Math::PI)
             cr.restore
             cr.stroke
         end

--- a/painting_with_cairo/drawing_text.rb
+++ b/painting_with_cairo/drawing_text.rb
@@ -6,14 +6,14 @@ class RubyApp < Gtk::Window
     def initialize
         super
     
-        set_title "Soulmate"
-        signal_connect "destroy" do 
+        set_title('Soulmate')
+        signal_connect('destroy') do 
             Gtk.main_quit 
         end
         
         init_ui
 
-        set_default_size 370, 240
+        set_default_size(370, 240)
         set_window_position(:center)
         
         show_all
@@ -23,7 +23,7 @@ class RubyApp < Gtk::Window
     
         @darea = Gtk::DrawingArea.new  
         
-        @darea.signal_connect "draw" do  
+        @darea.signal_connect('draw') do  
             on_expose
         end
     
@@ -35,24 +35,24 @@ class RubyApp < Gtk::Window
     
         cr = @darea.window.create_cairo_context  
         
-        cr.set_source_rgb 0.1, 0.1, 0.1
+        cr.set_source_rgb(0.1, 0.1, 0.1)
          
-        cr.select_font_face "Purisa", Cairo::FONT_SLANT_NORMAL, 
-            Cairo::FONT_WEIGHT_NORMAL
-        cr.set_font_size 13 
+        cr.select_font_face('Purisa', Cairo::FONT_SLANT_NORMAL, 
+            Cairo::FONT_WEIGHT_NORMAL)
+        cr.set_font_size(13)
        
-        cr.move_to 20, 30
-        cr.show_text "Most relationships seem so transitory"
-        cr.move_to 20, 60
-        cr.show_text "They're all good but not the permanent one"
-        cr.move_to 20, 120
-        cr.show_text "Who doesn't long for someone to hold"
-        cr.move_to 20, 150
-        cr.show_text "Who knows how to love without being told"
-        cr.move_to 20, 180
-        cr.show_text "Somebody tell me why I'm on my own"
-        cr.move_to 20, 210
-        cr.show_text "If there's a soulmate for everyone"
+        cr.move_to(20, 30)
+        cr.show_text('Most relationships seem so transitory')
+        cr.move_to(20, 60)
+        cr.show_text("They're all good but not the permanent one")
+        cr.move_to(20, 120)
+        cr.show_text("Who doesn't long for someone to hold")
+        cr.move_to(20, 150)
+        cr.show_text('Who knows how to love without being told')
+        cr.move_to(20, 180)
+        cr.show_text("Somebody tell me why I'm on my own")
+        cr.move_to(20, 210)
+        cr.show_text("If there's a soulmate for everyone")
     end
 end
 

--- a/painting_with_cairo/transparent_rectangles.rb
+++ b/painting_with_cairo/transparent_rectangles.rb
@@ -6,15 +6,15 @@ class RubyApp < Gtk::Window
     def initialize
         super
     
-        set_title "Transparent rectangles"
-        signal_connect "destroy" do 
+        set_title('Transparent rectangles')
+        signal_connect('destroy') do 
             Gtk.main_quit 
         end
         
         init_ui
 
-        set_default_size 590, 90
-        set_window_position Gtk::Window::POS_CENTER
+        set_default_size(590, 90)
+        set_window_position(:center)
         
         show_all
     end
@@ -36,8 +36,8 @@ class RubyApp < Gtk::Window
         cr = @darea.window.create_cairo_context  
         
         for i in (1..10)
-            cr.set_source_rgba 0, 0, 1, i*0.1
-            cr.rectangle 50*i, 20, 40, 40
+            cr.set_source_rgba(0, 0, 1, i*0.1)
+            cr.rectangle(50*i, 20, 40, 40)
             cr.fill
         end
     end


### PR DESCRIPTION
Hello,

I've fixed one of the cairo painting files since it used Gtk2. 

Also, I noticed the style to be random in some places. I've proposed some changes so it's more consistent.

Personally, I prefer:

```
    method( arg1, arg2 )
```

to

```
     method(art1, arg2)
```

I consider it to be more readable. This said, I've left out my preference to be consistent with the rest of your examples.

Feel free to leave the style normalization out of the pull request if you don't like it.
