### PR TITLE
Fixed typographical error, changed aplication to application in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ gtk3-ruby-examples
 This repo contains Gtk3 - Ruby examples. I got the examples from http://zetcode.com/gui/rubygtk/ and ported them to Gtk3. Readme also includes syntax differences.
 
 
-### Aplication Chooser
+### Application Chooser
 
 ```Ruby
 dialog = Gtk::AppChooserDialog.new(:parent => nil, :flags => Gtk::Dialog::Flags::MODAL, :file  => nil, :content_type => "text/plain")


### PR DESCRIPTION
@ebruAkagunduz, I've corrected a typographical error in the documentation of the [gtk3-ruby-examples](https://github.com/ebruAkagunduz/gtk3-ruby-examples) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.